### PR TITLE
Fix issue with webpack-karma

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,4 +1,4 @@
-var OriginalSource = require('webpack/lib/OriginalSource'),
+var RawSource = require('webpack/lib/RawSource'),
     extend = require('util')._extend;
 var Translation = require("./Translation");
 
@@ -58,15 +58,21 @@ AngularTranslatePlugin.prototype.registerTranslation = function (translation) {
  * When the compilation is complete, merge all the translations and emits the translations into the translations.json
  */
 AngularTranslatePlugin.prototype.emitResult = function (compilation, callback) {
-    var result = {};
+    var result = {},
+        translationIds = Object.keys(this.translations);
 
-    Object.keys(this.translations).forEach(function (translationId) {
-        var translation = this.translations[translationId];
-        result[translationId] = translation.text();
-    }, this);
 
-    var content = JSON.stringify(result, null, '\t');
-    compilation.assets[this.options.fileName] = new OriginalSource(content, this.options.fileName);
+    // Only create the file if it is not empty.
+    // Fixes an issue with karma-webpack where the build failes when the asset is emitted.
+    if (translationIds.length > 0) {
+        translationIds.forEach(function (translationId) {
+            var translation = this.translations[translationId];
+            result[translationId] = translation.text();
+        }, this);
+
+        var content = JSON.stringify(result, null, '\t');
+        compilation.assets[this.options.fileName] = new RawSource(content, this.options.fileName);
+    }
     callback();
 };
 module.exports = AngularTranslatePlugin;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-angular-translate",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Webpack plugin that extracts the translation-ids with the default text.",
   "repository": "https://github.com/DatenMetzgerX/webpack-angular-translate",
   "main": "index.js",

--- a/test/pluginSpecs.js
+++ b/test/pluginSpecs.js
@@ -25,12 +25,11 @@ function translationsTest(fileName, doneCallback, assertCallback) {
             });
         }
 
-        var translations = undefined;
+        var translations = {};
         if (stats.compilation.assets["translations.json"]) {
             translations = JSON.parse(stats.compilation.assets["translations.json"].source());
         }
 
-        assert.property(stats.compilation.assets, "translations.json");
         assertCallback(translations, stats);
 
         doneCallback();


### PR DESCRIPTION
Fix an issue where webpack-karma fails when using the plugin.
The problem seams to be that webpack-karma does not expect to have
any assets when no file have been included (yet). In this case
webpack-karma failes with a not helping error message.
To avoid the issue, suppress adding the asset if no translations
have been found (seams leggit anyway).