### PR TITLE
Correctly handle expression in attributes

### DIFF
--- a/src/html/html-loader.ts
+++ b/src/html/html-loader.ts
@@ -60,7 +60,12 @@ function loader(source: string, sourceMaps: any): void|string {
 
 function removeSuppressTranslationErrorAttributes(source: string): string {
     const $ = cheerio.load(source);
-    $(`[${SUPPRESS_ATTRIBUTE_NAME}]`).removeAttr(SUPPRESS_ATTRIBUTE_NAME);
+    const elementsWithSuppressAttribute = $(`[${SUPPRESS_ATTRIBUTE_NAME}]`);
+    if (elementsWithSuppressAttribute.length === 0) {
+        return source;
+    }
+
+    elementsWithSuppressAttribute.removeAttr(SUPPRESS_ATTRIBUTE_NAME);
     return $.html();
 }
 

--- a/src/html/ng-filters.ts
+++ b/src/html/ng-filters.ts
@@ -3,12 +3,26 @@
  * Group 1: Value passed to the filter
  * Group 2 (optional): Filters applied before the translate filter
  */
-const attributeRegex = /^\s*("[^"]*"|'[^']*'|[^|]+)(?:\s*\|\s*(?!translate)([^|\s]+))*\s*(?:\|\s*translate)\s*(?:\s*\|\s*[^|\s]+)*\s*$/i;
+const attributeRegex    = /\{\{\s*("[^"]*"|'[^']*'|[^|]+)(?:\s*\|\s*(?!translate)([^|\s]+))*\s*(?:\|\s*translate)\s*(?:\s*\|\s*[^|\s]+)*\s*}}/i;
 const angularExpression = /\{\{\s*("[^"]*"|'[^']*'|[^|]+)(?:\s*\|\s*(?!translate)([^|\s]+))*\s*(?:\|\s*translate)\s*(?:\s*\|\s*[^|\s]+)*\s*}}/igm;
 
+/**
+ * Match for an angular expression
+ */
 export interface AngularExpressionMatch {
+    /**
+     * The full string of characters matched, e.g. `'test' | translate | uppercase`
+     */
     match: string;
+
+    /**
+     * The value passed to the filter-chain
+     */
     value: string;
+
+    /**
+     * Filters applied before the translate filter
+     */
     previousFilters: string;
 }
 
@@ -21,6 +35,12 @@ function parseMatch(match: RegExpExecArray): AngularExpressionMatch {
     };
 }
 
+/**
+ * Matches the angular expressions from a a text. Returns a match for each expression in the
+ * passed in text
+ * @param html the text to search for angular expressions
+ * @returns {AngularExpressionMatch[]} an array with the found matches
+ */
 export function matchAngularExpressions(html: string): AngularExpressionMatch[] {
     const matches: AngularExpressionMatch[] = [];
     let match: RegExpExecArray;
@@ -36,6 +56,11 @@ export function matchAngularExpressions(html: string): AngularExpressionMatch[] 
     return matches;
 }
 
+/**
+ * Matches the angular expression used in an attribute text. Does
+ * @param attributeText the text of the attribute
+ * @returns The match of the angular expression if any.
+ */
 export function matchAttribute(attributeText: string): AngularExpressionMatch {
     const match = attributeRegex.exec(attributeText);
 

--- a/src/html/translate-html-parser.ts
+++ b/src/html/translate-html-parser.ts
@@ -13,6 +13,13 @@ function isAngularExpression(value: string): boolean {
     return angularExpressionRegex.test(value);
 }
 
+/**
+ * Visitor that implements the logic for extracting the translations.
+ * Elements with a translate directive where the content should be translated are registered in the closetag event.
+ * Translated attributes are registered in the opentag event
+ * Attributes translated with the translate filter are handled in the opentag event
+ * Expressions used in the body of an element are translated in the text event.
+ */
 export  default class TranslateHtmlParser implements htmlparser.Handler {
     context = new ElementContext(null, "root", null);
     parser: htmlparser.Parser;

--- a/src/js/js-loader.ts
+++ b/src/js/js-loader.ts
@@ -1,7 +1,6 @@
 import acorn = require("acorn");
 import escodegen = require("escodegen");
 import sourceMap = require("source-map");
-import types = require("ast-types");
 import TranslateLoaderContext from "../translate-loader-context";
 import TranslateVisitor from "./translate-visitor";
 import CodeWithSourceMap = SourceMap.CodeWithSourceMap;

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -19,7 +19,6 @@ export class Translation {
      * @param usage the usages where the translation with the given id and text is used
      */
     constructor(public id: string, public defaultText: string, usage: Usage|Usage[]) {
-
         if (usage instanceof Array) {
             this.usages = usage;
         } else {

--- a/test/html/element-context.specs.js
+++ b/test/html/element-context.specs.js
@@ -56,7 +56,7 @@ describe("ElementContext", function () {
 
             assert.notOk(rootContext.suppressDynamicTranslationErrors);
         });
-    })
+    });
 
     describe("asHtml", function () {
         it("shows the html for the element", function () {

--- a/test/html/ng-filters.specs.js
+++ b/test/html/ng-filters.specs.js
@@ -5,73 +5,89 @@ describe("the attribute expressions matches angular-filters in attributes (witho
     "use strict";
 
     it("matches a simple translate attribute", function () {
-        var result = filters.matchAttribute('"name" | translate');
+        var result = filters.matchAttribute('{{"name" | translate}}');
 
         assert.deepEqual(result, {
             value: '"name"',
-            match: '"name" | translate',
+            match: '{{"name" | translate}}',
             previousFilters: undefined
         });
     });
 
     it("matches an attribute with translate followed by another filter", function () {
-        var result = filters.matchAttribute('"name" | translate | limitTo:5');
+        var result = filters.matchAttribute('{{"name" | translate | limitTo:5}}');
 
         assert.deepEqual(result, {
             value: '"name"',
-            match: '"name" | translate | limitTo:5',
+            match: '{{"name" | translate | limitTo:5}}',
             previousFilters: undefined
         });
     });
 
     it("matches an attribute with translate followed by another filter without spaces", function () {
-        var result = filters.matchAttribute('"name"|translate|limitTo:5');
+        var result = filters.matchAttribute('{{"name"|translate|limitTo:5}}');
 
         assert.deepEqual(result, {
             value: '"name"',
-            match: '"name"|translate|limitTo:5',
+            match: '{{"name"|translate|limitTo:5}}',
             previousFilters: undefined
         });
     });
 
     it("matches an attribute with translate where translate follows another filter", function () {
-        var result = filters.matchAttribute('"name" | currency | translate');
+        var result = filters.matchAttribute('{{"name" | currency | translate}}');
 
         assert.deepEqual(result, {
             value: '"name"',
-            match: '"name" | currency | translate',
+            match: '{{"name" | currency | translate}}',
             previousFilters: "currency"
         });
     });
 
     it("matches an attribute with translate where translate follows another filter without spaces", function () {
-        var result = filters.matchAttribute('"name"|currency|translate');
+        var result = filters.matchAttribute('{{"name"|currency|translate}}');
 
         assert.deepEqual(result, {
             value: '"name"',
-            match: '"name"|currency|translate',
+            match: '{{"name"|currency|translate}}',
             previousFilters: "currency"
         });
     });
 
     it("matches property expressions", function () {
-        var result = filters.matchAttribute('user.sex | translate');
+        var result = filters.matchAttribute('{{user.sex | translate}}');
 
         assert.deepEqual(result, {
             value: 'user.sex',
-            match: 'user.sex | translate',
+            match: '{{user.sex | translate}}',
+            previousFilters: undefined
+        });
+    });
+
+    it("matches the expression inside a string", function () {
+        var result = filters.matchAttribute('Static Text: {{ "CHF" | translate }}');
+
+        assert.deepEqual(result, {
+            value: '"CHF"',
+            match: '{{ "CHF" | translate }}',
             previousFilters: undefined
         });
     });
 
     it("doesn't match an attribute containing translate without a filter pipe", function () {
-        var result = filters.matchAttribute('"name" translate');
+        var result = filters.matchAttribute('{{"name" translate}}');
 
         assert.isUndefined(result);
     });
 
     it("doesn't match '| translate", function () {
-        var result = filters.matchAttribute('| translate');
+        var result = filters.matchAttribute('{{| translate}}');
+
+        assert.isUndefined(result);
+    });
+
+    it("doesn't match a string literal that looks like an expression but misses the {}", function () {
+        var result = filters.matchAttribute('"value" | translate');
 
         assert.isUndefined(result);
     });
@@ -80,11 +96,11 @@ describe("the attribute expressions matches angular-filters in attributes (witho
      * Not supported in the current version
      */
     it("doesn't match the pipe in the string value", function () {
-        var result = filters.matchAttribute('"value|test" | translate');
+        var result = filters.matchAttribute('{{"value|test" | translate}}');
 
         assert.deepEqual(result, {
             value: '"value|test"',
-            match: '"value|test" | translate',
+            match: '{{"value|test" | translate}}',
             previousFilters: undefined
         });
     });

--- a/test/html/translate-html-parser.specs.js
+++ b/test/html/translate-html-parser.specs.js
@@ -1,6 +1,5 @@
 var assert = require("chai").assert;
 var sinon = require("sinon");
-var htmlparser = require("htmlparser2");
 
 var StatefulHtmlParser = require("../../dist/html/translate-html-parser").default;
 var Translation = require("../../dist/translation").default;
@@ -267,6 +266,15 @@ describe("StatefulHtmlParserSpecs", function () {
             parse("{{ 'test' | translate | uppercase }}");
 
             sinon.assert.calledWith(loaderContext.registerTranslation, new Translation("test", undefined, {
+                resource: "test.html",
+                loc: { line: 1, column: 0 }
+            }));
+        });
+
+        it("extracts the translation id if the translate filter is used inside a text body", function () {
+            parse("{{ ctrl.total | number:0 }} {{ 'USD' | translate }} ($)");
+
+            sinon.assert.calledWith(loaderContext.registerTranslation, new Translation("USD", undefined, {
                 resource: "test.html",
                 loc: { line: 1, column: 0 }
             }));

--- a/test/js/translate-visitor.specs.js
+++ b/test/js/translate-visitor.specs.js
@@ -8,7 +8,6 @@ var isCommentedWithSuppressError = require("../../dist/js/translate-visitor").is
 
 describe("TranslateVisitor", function () {
     var loaderContext;
-    var emitError;
     var visitor;
 
     beforeEach(function () {
@@ -144,7 +143,7 @@ describe("TranslateVisitor", function () {
             sinon.assert.calledWith(loaderContext.emitError, "Illegal argument for call to $translate: A call to $translate requires at least one argument that is the translation id. If you have registered the translation manually, you can use a /* suppress-dynamic-translation-error: true */ comment in the block of the function call to suppress this error. (test.js:1:1).");
         });
 
-        it("emits an error if the translation id is not a literal", function () {
+        it("emits an error if the translation id is not an array expression and neither a literal", function () {
             var translateCall = b.callExpression($translate, [b.identifier("test")]);
             translateCall.loc = { start: { line: 1, column: 1 } };
             loaderContext.resource = "test.js";
@@ -152,6 +151,16 @@ describe("TranslateVisitor", function () {
             visitor.visit(translateCall);
 
             sinon.assert.calledWith(loaderContext.emitError, "Illegal argument for call to $translate: The translation id should either be a string literal or an array containing string literals. If you have registered the translation manually, you can use a /* suppress-dynamic-translation-error: true */ comment in the block of the function call to suppress this error. (test.js:1:1).");
+        });
+
+        it("emits an error if any translation id in the passed in array is not a literal", function () {
+            var translateCall = b.callExpression($translate, [ b.arrayExpression([ b.literal("test"), b.identifier("notValid")])]);
+            translateCall.loc = { start: { line: 1, column: 0 }};
+            loaderContext.resource = "test.js";
+
+            visitor.visit(translateCall);
+
+            sinon.assert.calledWith(loaderContext.emitError, "Illegal argument for call to $translate: The array with the translation ids should only contain literals. If you have registered the translation manually, you can use a /* suppress-dynamic-translation-error: true */ comment in the block of the function call to suppress this error. (test.js:1:0).");
         });
 
         it("emits an error if the default text is not a literal", function () {


### PR DESCRIPTION
Only extract translations from attributes with an angular-expression. E.g. the translation should be extracted from `<a title='{{ "test" | translate }}' ></a>` but not from  `<a title='"test" | translate' ></a>` as it does not contain an expression.