### PR TITLE
Remove special handling for expressions in attributes

### DIFF
--- a/src/html/ng-filters.ts
+++ b/src/html/ng-filters.ts
@@ -3,7 +3,6 @@
  * Group 1: Value passed to the filter
  * Group 2 (optional): Filters applied before the translate filter
  */
-const attributeRegex    = /\{\{\s*("[^"]*"|'[^']*'|[^|]+)(?:\s*\|\s*(?!translate)([^|\s]+))*\s*(?:\|\s*translate)\s*(?:\s*\|\s*[^|\s]+)*\s*}}/i;
 const angularExpression = /\{\{\s*("[^"]*"|'[^']*'|[^|]+)(?:\s*\|\s*(?!translate)([^|\s]+))*\s*(?:\|\s*translate)\s*(?:\s*\|\s*[^|\s]+)*\s*}}/igm;
 
 /**
@@ -37,16 +36,16 @@ function parseMatch(match: RegExpExecArray): AngularExpressionMatch {
 
 /**
  * Matches the angular expressions from a a text. Returns a match for each expression in the
- * passed in text
- * @param html the text to search for angular expressions
+ * passed in text. Can be used to match the angular expressions inside an attribute or in the body text of an element.
+ * @param text the text to search for angular expressions
  * @returns {AngularExpressionMatch[]} an array with the found matches
  */
-export function matchAngularExpressions(html: string): AngularExpressionMatch[] {
+export function matchAngularExpressions(text: string): AngularExpressionMatch[] {
     const matches: AngularExpressionMatch[] = [];
     let match: RegExpExecArray;
 
     do {
-        match = angularExpression.exec(html);
+        match = angularExpression.exec(text);
 
         if (match) {
             matches.push(parseMatch(match));
@@ -54,18 +53,4 @@ export function matchAngularExpressions(html: string): AngularExpressionMatch[] 
     } while (match);
 
     return matches;
-}
-
-/**
- * Matches the angular expression used in an attribute text. Does
- * @param attributeText the text of the attribute
- * @returns The match of the angular expression if any.
- */
-export function matchAttribute(attributeText: string): AngularExpressionMatch {
-    const match = attributeRegex.exec(attributeText);
-
-    if (match) {
-        return parseMatch(match);
-    }
-    return undefined;
 }

--- a/test/html/ng-filters.specs.js
+++ b/test/html/ng-filters.specs.js
@@ -1,111 +1,6 @@
 var assert = require("chai").assert,
     filters = require('../../dist/html/ng-filters');
 
-describe("the attribute expressions matches angular-filters in attributes (without {{}}).", function () {
-    "use strict";
-
-    it("matches a simple translate attribute", function () {
-        var result = filters.matchAttribute('{{"name" | translate}}');
-
-        assert.deepEqual(result, {
-            value: '"name"',
-            match: '{{"name" | translate}}',
-            previousFilters: undefined
-        });
-    });
-
-    it("matches an attribute with translate followed by another filter", function () {
-        var result = filters.matchAttribute('{{"name" | translate | limitTo:5}}');
-
-        assert.deepEqual(result, {
-            value: '"name"',
-            match: '{{"name" | translate | limitTo:5}}',
-            previousFilters: undefined
-        });
-    });
-
-    it("matches an attribute with translate followed by another filter without spaces", function () {
-        var result = filters.matchAttribute('{{"name"|translate|limitTo:5}}');
-
-        assert.deepEqual(result, {
-            value: '"name"',
-            match: '{{"name"|translate|limitTo:5}}',
-            previousFilters: undefined
-        });
-    });
-
-    it("matches an attribute with translate where translate follows another filter", function () {
-        var result = filters.matchAttribute('{{"name" | currency | translate}}');
-
-        assert.deepEqual(result, {
-            value: '"name"',
-            match: '{{"name" | currency | translate}}',
-            previousFilters: "currency"
-        });
-    });
-
-    it("matches an attribute with translate where translate follows another filter without spaces", function () {
-        var result = filters.matchAttribute('{{"name"|currency|translate}}');
-
-        assert.deepEqual(result, {
-            value: '"name"',
-            match: '{{"name"|currency|translate}}',
-            previousFilters: "currency"
-        });
-    });
-
-    it("matches property expressions", function () {
-        var result = filters.matchAttribute('{{user.sex | translate}}');
-
-        assert.deepEqual(result, {
-            value: 'user.sex',
-            match: '{{user.sex | translate}}',
-            previousFilters: undefined
-        });
-    });
-
-    it("matches the expression inside a string", function () {
-        var result = filters.matchAttribute('Static Text: {{ "CHF" | translate }}');
-
-        assert.deepEqual(result, {
-            value: '"CHF"',
-            match: '{{ "CHF" | translate }}',
-            previousFilters: undefined
-        });
-    });
-
-    it("doesn't match an attribute containing translate without a filter pipe", function () {
-        var result = filters.matchAttribute('{{"name" translate}}');
-
-        assert.isUndefined(result);
-    });
-
-    it("doesn't match '| translate", function () {
-        var result = filters.matchAttribute('{{| translate}}');
-
-        assert.isUndefined(result);
-    });
-
-    it("doesn't match a string literal that looks like an expression but misses the {}", function () {
-        var result = filters.matchAttribute('"value" | translate');
-
-        assert.isUndefined(result);
-    });
-
-    /**
-     * Not supported in the current version
-     */
-    it("doesn't match the pipe in the string value", function () {
-        var result = filters.matchAttribute('{{"value|test" | translate}}');
-
-        assert.deepEqual(result, {
-            value: '"value|test"',
-            match: '{{"value|test" | translate}}',
-            previousFilters: undefined
-        });
-    });
-});
-
 describe("the filter expression matches angular-filters anywhere in the code using {{}}", function () {
    "use strict";
 
@@ -163,6 +58,46 @@ describe("the filter expression matches angular-filters anywhere in the code usi
         }]);
     });
 
+    it("matches an attribute with translate followed by another filter without spaces", function () {
+        var result = filters.matchAngularExpressions('{{"name"|translate|limitTo:5}}');
+
+        assert.deepEqual(result, [{
+            value: '"name"',
+            match: '{{"name"|translate|limitTo:5}}',
+            previousFilters: undefined
+        }]);
+    });
+
+    it("matches an attribute with translate where translate follows another filter without spaces", function () {
+        var result = filters.matchAngularExpressions('{{"name"|currency|translate}}');
+
+        assert.deepEqual(result, [{
+            value: '"name"',
+            match: '{{"name"|currency|translate}}',
+            previousFilters: "currency"
+        }]);
+    });
+
+    it("matches property expressions", function () {
+        var result = filters.matchAngularExpressions('{{user.sex | translate}}');
+
+        assert.deepEqual(result, [{
+            value: 'user.sex',
+            match: '{{user.sex | translate}}',
+            previousFilters: undefined
+        }]);
+    });
+
+    it("matches the expression inside a string", function () {
+        var result = filters.matchAngularExpressions('Static Text: {{ "CHF" | translate }}');
+
+        assert.deepEqual(result, [{
+            value: '"CHF"',
+            match: '{{ "CHF" | translate }}',
+            previousFilters: undefined
+        }]);
+    });
+
     it("doesn't match an expression without translate filter", function () {
         var result = filters.matchAngularExpressions("{{ 1 + 2 }}");
 
@@ -173,5 +108,30 @@ describe("the filter expression matches angular-filters anywhere in the code usi
         var result = filters.matchAngularExpressions("{{ '{{1 + 2}}' }}");
 
         assert.deepEqual(result, []);
+    });
+
+    it("doesn't match '| translate", function () {
+        var result = filters.matchAngularExpressions('{{| translate}}');
+
+        assert.deepEqual(result, []);
+    });
+
+    it("doesn't match a string literal that looks like an expression but misses the {}", function () {
+        var result = filters.matchAngularExpressions('"value" | translate');
+
+        assert.deepEqual(result, []);
+    });
+
+    /**
+     * Not supported in the current version
+     */
+    it("doesn't match the pipe in the string value", function () {
+        var result = filters.matchAngularExpressions('{{"value|test" | translate}}');
+
+        assert.deepEqual(result, [{
+            value: '"value|test"',
+            match: '{{"value|test" | translate}}',
+            previousFilters: undefined
+        }]);
     });
 });

--- a/test/html/translate-html-parser.specs.js
+++ b/test/html/translate-html-parser.specs.js
@@ -317,6 +317,20 @@ describe("StatefulHtmlParserSpecs", function () {
             }));
         });
 
+        it("extracts multiple translations from an attribute with translate filters", function () {
+            parse("<img src='xy' title=\"Fixed Text: {{ 'Waterfall' | translate }} and {{ 'Other' | translate }}\" />");
+
+            sinon.assert.calledWith(loaderContext.registerTranslation, new Translation("Waterfall", undefined, {
+                resource: "test.html",
+                loc: { line: 1, column: 0 }
+            }));
+
+            sinon.assert.calledWith(loaderContext.registerTranslation, new Translation("Other", undefined, {
+                resource: "test.html",
+                loc: { line: 1, column: 0 }
+            }));
+        });
+
         it("emits an error if the translate filter is not the first in the filter chain", function () {
             parse("<img src='xz' alt='{{ \"title\" | uppercase | translate }}' />");
 


### PR DESCRIPTION
Use the same hanling as for expressions in the text of an html element as there is no difference.